### PR TITLE
Fix sitemap generation

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,4 +3,5 @@ layout: 404
 title: 404
 description: The page you are looking for couldn't be found.
 permalink: /404.html
+sitemap: false
 ---

--- a/assets/css/fonts.scss
+++ b/assets/css/fonts.scss
@@ -1,4 +1,5 @@
 ---
+sitemap: false
 ---
 /* titillium-web-300 - latin */
 @font-face {

--- a/assets/css/preview.scss
+++ b/assets/css/preview.scss
@@ -1,3 +1,4 @@
 ---
+sitemap: false
 ---
 @import "preview";

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,3 +1,4 @@
 ---
+sitemap: false
 ---
 @import "jekflix";

--- a/contact.html
+++ b/contact.html
@@ -4,4 +4,5 @@ title: Contact
 noindex: true
 description: Let's talk.
 permalink: /contact/
+sitemap: false
 ---

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,6 @@
 ---
 layout: null
+sitemap: false
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/index.markdown
+++ b/index.markdown
@@ -3,4 +3,5 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
 layout: home
+sitemap: false
 ---

--- a/message-sent.html
+++ b/message-sent.html
@@ -1,4 +1,5 @@
 ---
 layout: message-sent
 permalink: /contact/message-sent/
+sitemap: false
 ---

--- a/pages/about-1.md
+++ b/pages/about-1.md
@@ -5,6 +5,7 @@ date: '2020-02-27 01:53:59'
 title: About
 permalink: /about/
 description: Some description.
+sitemap: false
 ---
 
 <img class="img-rounded" src="/assets/img/uploads/profile.png" alt="kripto istanbul yazar" width="200">

--- a/pages/about.md
+++ b/pages/about.md
@@ -4,6 +4,7 @@ title: Hakkımızda
 noindex: true
 description: Some description.
 permalink: /about/
+sitemap: false
 ---
 
 <img class="img-rounded" src="/assets/img/uploads/profile.png" alt="Thiago Rossener" width="200">

--- a/search.json
+++ b/search.json
@@ -1,3 +1,4 @@
 ---
 layout: search
+sitemap: false
 ---

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,17 +4,13 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in site.pages %}
+        {% unless page.sitemap == false or page.noindex == true %}
         <url>
             <loc>{{ page.url | prepend: site.baseurl | prepend: site.url }}</loc>
-            {% if page.layout == 'main' %}
-                <changefreq>yearly</changefreq>
-                <priority>0.1</priority>
-                <lastmod>{{ site.time | date: "%Y-%m-%d" }}</lastmod>
-            {% else %}
-                <changefreq>yearly</changefreq>
-                <priority>0.1</priority>
-            {% endif %}
+            <changefreq>yearly</changefreq>
+            <priority>0.1</priority>
         </url>
+        {% endunless %}
     {% endfor %}
     {% for post in site.posts %}
         <url>


### PR DESCRIPTION
## Summary
- exclude site pages like CSS files and contact-related pages from the sitemap
- filter out pages marked as `sitemap: false` or `noindex: true` when generating the sitemap

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845b4d252cc832189a79418809c31b2