### PR TITLE
Add prod sync workflow

### DIFF
--- a/.github/workflows/sync-prod.yml
+++ b/.github/workflows/sync-prod.yml
@@ -1,0 +1,34 @@
+name: Sync prod with gh-pages
+
+on:
+  push:
+    branches: [gh-pages]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Prepare prod branch
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          if git rev-parse --verify origin/prod >/dev/null 2>&1; then
+            git checkout prod
+          else
+            git checkout --orphan prod
+            git reset --hard
+          fi
+          git rm -rf .
+          cp -r _site/* .
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Sync prod with gh-pages"
+          git push origin prod

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # kripto.istanbul
 kripto.istanbul site dosyaları
+
+## Deployment
+
+Updates to the `gh-pages` branch automatically sync the contents of the `_site`
+folder to the `prod` branch using a GitHub Actions workflow.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to sync `_site` from `gh-pages` to `prod`
- document automated deployment in README

## Testing
- `npm test` *(fails: Missing script)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c512990c832183ea9418955df534